### PR TITLE
use libjpeg-turbo 1.3.1 as dep in Ghostscript easyconfig, 1.4.x doesn't work

### DIFF
--- a/easybuild/easyconfigs/g/Ghostscript/Ghostscript-9.16-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/g/Ghostscript/Ghostscript-9.16-goolf-1.7.20.eb
@@ -21,7 +21,7 @@ dependencies = [
     ('freetype', '2.6'),
     ('fontconfig', '2.11.94'),
     ('GLib', '2.45.2'),
-    ('libjpeg-turbo', '1.4.1'),
+    ('libjpeg-turbo', '1.3.1'),  # note: libjpeg-turbo 1.4.[01] doesn't work
     ('expat', '2.1.0'),
     ('cairo', '1.14.2'),
     ('LibTIFF', '4.0.4'),

--- a/easybuild/easyconfigs/g/Ghostscript/Ghostscript-9.16-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/g/Ghostscript/Ghostscript-9.16-goolf-1.7.20.eb
@@ -21,6 +21,7 @@ dependencies = [
     ('freetype', '2.6'),
     ('fontconfig', '2.11.94'),
     ('GLib', '2.45.2'),
+    ('libjpeg-turbo', '1.4.1'),
     ('expat', '2.1.0'),
     ('cairo', '1.14.2'),
     ('LibTIFF', '4.0.4'),


### PR DESCRIPTION
for https://github.com/hpcugent/easybuild-easyconfigs/pull/1705

using libjpeg-turbo 1.3.1 works, since that's compatible with the stuff that's included in the `jpeg` subdirectory in the Ghostscript tarball

However, the `gs` binary isn't linked to the `libjpeg.so` provided by `libjpeg-turob`:

```
$ ml

Currently Loaded Modules:
  1) GCC/4.8.4                  5) OpenBLAS/0.2.13-GCC-4.8.4-LAPACK-3.5.0                      9) goolf/1.7.20                13) fontconfig/2.11.94-goolf-1.7.20  17) NASM/2.11.05-goolf-1.7.20         21) pixman/0.32.6-goolf-1.7.20
  2) numactl/2.0.10-GCC-4.8.4   6) gompi/1.7.20                                               10) zlib/1.2.8-goolf-1.7.20     14) libffi/3.1-goolf-1.7.20          18) libjpeg-turbo/1.3.1-goolf-1.7.20  22) cairo/1.14.2-goolf-1.7.20
  3) hwloc/1.10.1-GCC-4.8.4     7) FFTW/3.3.4-gompi-1.7.20                                    11) libpng/1.6.17-goolf-1.7.20  15) gettext/0.19.2-goolf-1.7.20      19) expat/2.1.0-goolf-1.7.20          23) LibTIFF/4.0.4-goolf-1.7.20
  4) OpenMPI/1.8.4-GCC-4.8.4    8) ScaLAPACK/2.0.2-gompi-1.7.20-OpenBLAS-0.2.13-LAPACK-3.5.0  12) freetype/2.6-goolf-1.7.20   16) GLib/2.45.2-goolf-1.7.20         20) bzip2/1.0.6-goolf-1.7.20          24) Ghostscript/9.16-goolf-1.7.20

$ ldd appl_taito/software/Ghostscript/9.16-goolf-1.7.20/bin/gs 
    linux-vdso.so.1 =>  (0x00007fbe2b005000)
    libtiff.so.5 => /homeappl/home/hoste/appl_taito/software/LibTIFF/4.0.4-goolf-1.7.20/lib/libtiff.so.5 (0x00007fbe2ad92000)
    libdl.so.2 => /lib64/libdl.so.2 (0x00007fbe2ab6c000)
    libm.so.6 => /lib64/libm.so.6 (0x00007fbe2a8e7000)
    libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fbe2a6ca000)
    libidn.so.11 => /lib64/libidn.so.11 (0x00007fbe2a498000)
    libfontconfig.so.1 => /homeappl/home/hoste/appl_taito/software/fontconfig/2.11.94-goolf-1.7.20/lib/libfontconfig.so.1 (0x00007fbe2a256000)
    libfreetype.so.6 => /homeappl/home/hoste/appl_taito/software/freetype/2.6-goolf-1.7.20/lib/libfreetype.so.6 (0x00007fbe29fc0000)
    libc.so.6 => /lib64/libc.so.6 (0x00007fbe29c2c000)
    libjpeg.so.62 => /usr/lib64/libjpeg.so.62 (0x00007fbe299db000)
    libz.so.1 => /homeappl/home/hoste/appl_taito/software/zlib/1.2.8-goolf-1.7.20/lib/libz.so.1 (0x00007fbe297c6000)
    /lib64/ld-linux-x86-64.so.2 (0x00007fbe2b006000)
    libbz2.so.1 => /lib64/libbz2.so.1 (0x00007fbe295b4000)
    libpng16.so.16 => /homeappl/home/hoste/appl_taito/software/libpng/1.6.17-goolf-1.7.20/lib/libpng16.so.16 (0x00007fbe29383000)
    libexpat.so.1 => /homeappl/home/hoste/appl_taito/software/expat/2.1.0-goolf-1.7.20/lib/libexpat.so.1 (0x00007fbe2915a000)

$ ls $EBROOTLIBJPEGMINTURBO/lib
libjpeg.a  libjpeg.la  libjpeg.so  libjpeg.so.8  libjpeg.so.8.0.2  libturbojpeg.a  libturbojpeg.la  libturbojpeg.so  libturbojpeg.so.0  libturbojpeg.so.0.0.0
```
