### PR TITLE
use GLib 2.44.1 (stable) rather than 2.45.x (development)

### DIFF
--- a/easybuild/easyconfigs/g/GLib/GLib-2.44.1-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/g/GLib/GLib-2.44.1-goolf-1.7.20.eb
@@ -1,7 +1,7 @@
 easyblock = 'ConfigureMake'
 
 name = 'GLib'
-version = '2.45.2'
+version = '2.44.1'
 
 homepage = 'http://www.gtk.org/'
 description = """GLib is one of the base libraries of the GTK+ project"""

--- a/easybuild/easyconfigs/g/Ghostscript/Ghostscript-9.16-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/g/Ghostscript/Ghostscript-9.16-goolf-1.7.20.eb
@@ -20,7 +20,7 @@ dependencies = [
     ('libpng', '1.6.17'),  
     ('freetype', '2.6'),
     ('fontconfig', '2.11.94'),
-    ('GLib', '2.45.2'),
+    ('GLib', '2.44.1'),
     ('libjpeg-turbo', '1.3.1'),  # note: libjpeg-turbo 1.4.[01] doesn't work
     ('expat', '2.1.0'),
     ('cairo', '1.14.2'),


### PR DESCRIPTION
for https://github.com/hpcugent/easybuild-easyconfigs/pull/1705
